### PR TITLE
feat: Migrate to using global jinja function instead of registering view_func's to each route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2.0.0] - 2025-03-18
+### Changed
+- No longer registers a function to each route, instead exposes a Jinja function to dynamically build the form, `load_form()`
+- Path to the form template must now be passed to the `load_form` function. This eliminates the need to include the form template in each template that uses it
+
+### Added
+- Error handling
+
 ## [1.0.0] - 2025-03-18
 ### Added
 - Initial project release

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ form_loader.load_forms()
 You can then call the `load_forms` function from within a Jinja template. Providing a path for the `form-data.json` (required) and a formId (optional):
 
 ```
-{{ load_form('/aws', 1234) }}
+{{ load_form('/aws', 1234) | safe }}
 ```
 
 See the [full guide](https://webteam.canonical.com/practices/automated-form-builder) for more information.

--- a/README.md
+++ b/README.md
@@ -2,18 +2,27 @@
 
 Flask extension that generates unique HTML forms based on `json` data and registers them to URLs.
 
-## Install
+## Installation and usage
 
 Install the project with pip: `pip install canonicalwebteam.form-generator`
 
-You can then initialize it by passing a Flask app instance and load the forms:
+You can then initialize it by passing a Flask app instance and path to the form template, and then load the forms:
 
 ```
 from canonicalwebteam.form_generator import FormGenerator
 
+form_template_path = "path/to/form-template.html"
 form_loader = FormGenerator(app)
 form_loader.load_forms()
 ```
+
+You can then call the `load_forms` function from within a Jinja template. Providing a path for the `form-data.json` (required) and a formId (optional):
+
+```
+{{ load_form('/aws', 1234) }}
+```
+
+See the [full guide](https://webteam.canonical.com/practices/automated-form-builder) for more information.
 
 ## Local development
 

--- a/canonicalwebteam/form_generator/app.py
+++ b/canonicalwebteam/form_generator/app.py
@@ -1,5 +1,5 @@
-import json
-import flask
+from json import load as json_load, JSONDecodeError
+from flask import abort, render_template
 from pathlib import Path
 
 
@@ -16,7 +16,7 @@ class FormGenerator:
         self.templates_folder = Path(app.root_path).parent / "templates"
         self.form_metadata = {}
 
-        # Register Jinja function globally
+        # Register Jinja function so it can be accessed in templates
         self.app.jinja_env.globals["load_form"] = self.load_form
 
     def load_forms(self):
@@ -25,9 +25,37 @@ class FormGenerator:
         stores limited metadata.
         """
         for file_path in self.templates_folder.rglob("form-data.json"):
-            with open(file_path) as forms_json:
-                data = json.load(forms_json)
-                self._store_metadata(file_path, data["form"])
+            try:
+                with open(file_path) as forms_json:
+                    data = json_load(forms_json)
+                    if "form" not in data:
+                        abort(
+                            400,
+                            description=(
+                                "The JSON should have a 'form' key containing"
+                                f" the form data: {file_path}"
+                            ),
+                        )
+                    self._store_metadata(file_path, data["form"])
+            except (
+                JSONDecodeError,
+                FileNotFoundError,
+            ) as e:
+                abort(
+                    500,
+                    description=(
+                        "Error processing form data from "
+                        f"{file_path}: {str(e)}"
+                    ),
+                )
+            except Exception as e:
+                abort(
+                    500,
+                    description=(
+                        "Error processing form data from "
+                        f"{file_path}: {str(e)}"
+                    ),
+                )
 
     def _store_metadata(self, file_path: Path, forms_data: dict):
         """
@@ -37,49 +65,73 @@ class FormGenerator:
         for path, form in forms_data.items():
             self.form_metadata[path] = {
                 "file_path": file_path,
-                "template": form["templatePath"].rsplit(".", 1)[
-                    0
-                ],  # Remove file extension
+                "template": self._remove_file_extension(form["templatePath"]),
             }
 
             for child_path in form.get("childrenPaths", []):
                 processed_path = self._process_child_path(child_path)
                 self.form_metadata[processed_path] = {
                     "file_path": file_path,
-                    "template": form["templatePath"].rsplit(".", 1)[0],
+                    "template": self._remove_file_extension(
+                        form["templatePath"]
+                    ),
+                    "is_child": True,
                 }
 
-    def load_form(self, form_path: Path) -> str:
+    def load_form(self, form_path: Path, formId: int = None) -> str:
         """
         Jinja function that return a html string form.
-        
-        Usage: {{ load_form('/aws') }}
+
+        :param form_path: The path to the parent form
+        :return: HTML form
+        :usage: {{ load_form('/aws') }}
         """
         form_info = self.form_metadata.get(form_path)
-        # ADD ERROR HANDLING
+        if form_info is None:
+            abort(
+                404,
+                description=f"Form metadata not found for path: {form_path}",
+            )
+
+        is_child = form_info.get("is_child", False)
 
         form_json = self._load_form_json(form_info["file_path"]).get(form_path)
-        # ADD ERROR HANDLING
+        if not form_json:
+            abort(
+                404, description=f"Form data not found for path: {form_path}"
+            )
 
-        return flask.render_template(
-            self.form_template_path,
-            fieldsets=form_json["fieldsets"],
-            formData=form_json["formData"],
-            isModal=form_json.get("isModal"),
-            modalId=form_json.get("modalId"),
-            path=form_path,
-        )
+        try:
+            return render_template(
+                self.form_template_path,
+                fieldsets=form_json["fieldsets"],
+                formData=form_json["formData"],
+                isModal=form_json.get("isModal"),
+                modalId=form_json.get("modalId"),
+                path=form_path if is_child else None,
+                formId=formId,
+            )
+        except Exception as e:
+            abort(
+                500,
+                f"Error rendering template for {form_path}: {str(e)}",
+            )
 
     def _load_form_json(self, file_path: Path) -> dict:
         """
         Loads form data from a JSON file.
         """
         try:
-            with open(file_path) as forms_json:
-                return json.load(forms_json).get("form", {})
-        except (FileNotFoundError, json.JSONDecodeError):
-            return {}
-            # ADD ERROR HANDLING
+            with open(file_path, encoding="utf-8") as form_json:
+                return json_load(form_json).get("form", {})
+        except FileNotFoundError:
+            abort(404, description=f"JSON file not found: {file_path} \n")
+        except JSONDecodeError:
+            abort(400, description=f"Invalid JSON format: {file_path} \n")
+        except Exception as e:
+            abort(
+                500, description=f"Unexpected error loading JSON: {str(e)} \n"
+            )
 
     @staticmethod
     def _process_child_path(child_path: str) -> str:
@@ -92,3 +144,10 @@ class FormGenerator:
             if path_split[-1] == "index"
             else child_path
         )
+
+    @staticmethod
+    def _remove_file_extension(file_path: Path) -> str:
+        """
+        Removes file extension from a file path.
+        """
+        return file_path.rsplit(".", 1)[0]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.form-generator",
-    version="1.0.0",
+    version="2.0.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.form-generator",
@@ -17,6 +17,5 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=[
         "Flask",
-        "Jinja2",
     ],
 )


### PR DESCRIPTION
*note: The docs should only be update once this is actually ready to go live. I created issues for this under the [form-generator epic](https://warthogs.atlassian.net/browse/WD-18047)*

## Done

- Loads only the metadata to a lookup dict on build, instead of loading all form data
- Migrates from registering a view func for each individual route, to exposing a global jinja function that dynamically builds the forms on request
- `load_forms` now requires the passing of the form template
- `load_forms` takes an optional `formId`, to change the form ID set in the `form-data.json`
- Adds error handling

## QA

Visit the following links and ensure the form loads and submits to marketo. These represent the 4 different types of form that exist.

A normal form - https://ubuntu-com-14880.demos.haus/aws
A child form - https://ubuntu-com-14880.demos.haus/aws/pro
A form-data.json with two forms inside - https://ubuntu-com-14880.demos.haus/security/docker-images
A form with a new formID passed - https://ubuntu-com-14880.demos.haus/internet-of-things/appstore
