### PR TITLE
Add title, introText, returnUrl & lpUrl to load_form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.2.0] - 2026-01-12
+### Added
+- Add customizable formData parameters to load_form: title, introText, returnUrl, and lpUrl. These optional parameters override the values from form-data.json when provided.
+
 ## [2.1.1] - 2026-01-12
 ### Fixed
 - Fixed the issue of loading of forms using the paths in `childrenPaths` not working

--- a/canonicalwebteam/form_generator/app.py
+++ b/canonicalwebteam/form_generator/app.py
@@ -105,7 +105,7 @@ class FormGenerator:
         :param introText: Form description (optional)
         :param returnUrl: Return URL on form submission (optional)
         :param lpUrl: Landing page URL (optional)
-        :param lpUrl: Landing page ID (optional)
+        :param lpId: Landing page ID (optional)
         :param product: Product name (optional)
         :return: HTML form
         :usage: {{ load_form('/aws', title='Talk to our experts',

--- a/canonicalwebteam/form_generator/app.py
+++ b/canonicalwebteam/form_generator/app.py
@@ -155,6 +155,7 @@ class FormGenerator:
                 modalId=form_json.get("modalId"),
                 path=form_path if is_child else None,
                 formId=formId,
+                formPath=form_path,
             )
         except Exception as e:
             abort(

--- a/canonicalwebteam/form_generator/app.py
+++ b/canonicalwebteam/form_generator/app.py
@@ -153,9 +153,9 @@ class FormGenerator:
                 formData=form_data,
                 isModal=is_modal,
                 modalId=form_json.get("modalId"),
-                path=form_path if is_child else None,
+                parentPath=form_path if is_child else None,
                 formId=formId,
-                formPath=form_path,
+                path=form_path,
             )
         except Exception as e:
             abort(

--- a/canonicalwebteam/form_generator/app.py
+++ b/canonicalwebteam/form_generator/app.py
@@ -153,9 +153,9 @@ class FormGenerator:
                 formData=form_data,
                 isModal=is_modal,
                 modalId=form_json.get("modalId"),
-                parentPath=form_path if is_child else None,
+                path=form_path if is_child else None,
                 formId=formId,
-                path=form_path,
+                formPath=form_path,
             )
         except Exception as e:
             abort(

--- a/canonicalwebteam/form_generator/app.py
+++ b/canonicalwebteam/form_generator/app.py
@@ -92,6 +92,8 @@ class FormGenerator:
         introText: str = None,
         returnUrl: str = None,
         lpUrl: str = None,
+        lpId: int = None,
+        product: str = None,
     ) -> str:
         """
         Jinja function that returns an HTML string form.
@@ -103,6 +105,8 @@ class FormGenerator:
         :param introText: Form description (optional)
         :param returnUrl: Return URL on form submission (optional)
         :param lpUrl: Landing page URL (optional)
+        :param lpUrl: Landing page ID (optional)
+        :param product: Product name (optional)
         :return: HTML form
         :usage: {{ load_form('/aws', title='Talk to our experts',
             returnUrl='/contact#contact-form-success') }}
@@ -132,14 +136,16 @@ class FormGenerator:
             form_data = form_json.get("formData", {}).copy()
 
             # Override with provided parameters if they are not None
-            if title is not None:
-                form_data["title"] = title
-            if introText is not None:
-                form_data["introText"] = introText
-            if returnUrl is not None:
-                form_data["returnUrl"] = returnUrl
-            if lpUrl is not None:
-                form_data["lpUrl"] = lpUrl
+            for key, value in [
+                ("title", title),
+                ("introText", introText),
+                ("returnUrl", returnUrl),
+                ("lpUrl", lpUrl),
+                ("lpId", lpId),
+                ("product", product),
+            ]:
+                if value is not None:
+                    form_data[key] = value
 
             return render_template(
                 self.form_template_path,

--- a/canonicalwebteam/form_generator/app.py
+++ b/canonicalwebteam/form_generator/app.py
@@ -84,14 +84,28 @@ class FormGenerator:
                 }
 
     def load_form(
-        self, form_path: Path, formId: int = None, isModal: bool = None
+        self,
+        form_path: Path,
+        formId: int = None,
+        isModal: bool = None,
+        title: str = None,
+        introText: str = None,
+        returnUrl: str = None,
+        lpUrl: str = None,
     ) -> str:
         """
-        Jinja function that return a html string form.
+        Jinja function that returns an HTML string form.
 
         :param form_path: The path to the parent form
+        :param formId: Marketo ID for the form (optional)
+        :param isModal: boolean to determine if form is a modal (optional)
+        :param title: Title of form (optional)
+        :param introText: Form description (optional)
+        :param returnUrl: Return URL on form submission (optional)
+        :param lpUrl: Landing page URL (optional)
         :return: HTML form
-        :usage: {{ load_form('/aws') }}
+        :usage: {{ load_form('/aws', title='Talk to our experts',
+            returnUrl='/contact#contact-form-success') }}
         """
         form_info = self.form_metadata.get(form_path)
         if form_info is None:
@@ -113,10 +127,24 @@ class FormGenerator:
 
         try:
             is_modal = form_json.get("isModal") if isModal is None else isModal
+
+            # Start with the base formData from JSON
+            form_data = form_json.get("formData", {}).copy()
+
+            # Override with provided parameters if they are not None
+            if title is not None:
+                form_data["title"] = title
+            if introText is not None:
+                form_data["introText"] = introText
+            if returnUrl is not None:
+                form_data["returnUrl"] = returnUrl
+            if lpUrl is not None:
+                form_data["lpUrl"] = lpUrl
+
             return render_template(
                 self.form_template_path,
                 fieldsets=form_json["fieldsets"],
-                formData=form_json["formData"],
+                formData=form_data,
                 isModal=is_modal,
                 modalId=form_json.get("modalId"),
                 path=form_path if is_child else None,

--- a/canonicalwebteam/form_generator/tests/test_app.py
+++ b/canonicalwebteam/form_generator/tests/test_app.py
@@ -183,7 +183,7 @@ class TestFormGenerator(unittest.TestCase):
         self.assertEqual(args[0], self.form_template_path)
         self.assertEqual(kwargs["fieldsets"], [{"fields": []}])
         self.assertEqual(kwargs["formData"], {"title": "Test Form"})
-        self.assertIsNone(kwargs["path"])
+        self.assertIsNone(kwargs["parentPath"])
 
     @patch("canonicalwebteam.form_generator.app.render_template")
     def test_load_child_form(self, mock_render_template):

--- a/canonicalwebteam/form_generator/tests/test_app.py
+++ b/canonicalwebteam/form_generator/tests/test_app.py
@@ -183,7 +183,8 @@ class TestFormGenerator(unittest.TestCase):
         self.assertEqual(args[0], self.form_template_path)
         self.assertEqual(kwargs["fieldsets"], [{"fields": []}])
         self.assertEqual(kwargs["formData"], {"title": "Test Form"})
-        self.assertIsNone(kwargs["parentPath"])
+        self.assertIsNone(kwargs["path"])
+        self.assertEqual(kwargs["formPath"], "/test")
 
     @patch("canonicalwebteam.form_generator.app.render_template")
     def test_load_child_form(self, mock_render_template):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.form-generator",
-    version="2.1.1",
+    version="2.2.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.form-generator",


### PR DESCRIPTION
### Add customizable formData parameters to load_form function
This PR enhances the load_form function to accept optional parameters that allow customization of form data fields directly from template calls.

### Done
- Added optional parameters to load_form: title, introText, returnUrl, and lpUrl
- These parameters override the corresponding values from form-data.json when provided

```bash
{{ load_form('/aws', 
    title='Talk to our relational databases experts', 
    introText='Get expert help with PostgreSQL',
    returnUrl='/data/postgresql#contact-form-success') }}
```

### QA
Prod
Default title: 
- Code https://github.com/canonical/canonical.com/blob/a6acfd0317cfa5dad85640b15d4b9a030bdd6a1d/templates/data/mysql/form-data.json#L12
- Prod https://canonical.com/data/mysql/managed#get-in-touch

Demo
Changed title in code: 
- Code https://github.com/canonical/canonical.com/pull/2169/changes#diff-de1e3d96aff83356be6c09e98ee200e595f7af62fc8720ee4d5532993637b614R483-R487
- Demo link: https://canonical-com-2169.demos.haus/data/mysql/managed#get-in-touch

### Post Merge

- [x] Update [documentation](https://webteam.canonical.com/practices/automated-form-builder)